### PR TITLE
Added new players from week 1

### DIFF
--- a/IPR.csv
+++ b/IPR.csv
@@ -126,6 +126,7 @@
 4,Ben Simmons
 1,Beni Rose
 1,Benjamin Lutz
+1,Benjamin Schubert
 1,Benny Phanichkul
 3,Benton Seybold
 1,Beth Petrick
@@ -174,7 +175,9 @@
 3,Brian Headley
 2,Brian Hegstad
 5,Brian Hyder
+1,Brian Kirk
 1,Brian Meaker
+1,Bryan Mills
 1,Brian O'Neill WA
 1,Brian Shepard
 2,Brian Welliver
@@ -266,6 +269,7 @@
 1,Clay Vondra
 1,Clayton Baber
 1,Clayton Brumbaugh
+2,Clayton Coffman
 1,Clayton Malcom
 1,Clayton Michael
 4,Clayton Stetz
@@ -543,6 +547,7 @@
 10,Jasmine Palmer
 1,Jason Andersen
 1,Jason Bliss
+1,Jason Boekeloo
 1,Jason Borhauer
 2,Jason Burton
 5,Jason Galginaitis
@@ -639,6 +644,7 @@
 1,JohnNils Olson
 3,Johnny Hill
 1,Johnny Mayer
+1,Jon Bell
 1,Jon Burris
 5,Jon Jacob
 2,Jon Jow
@@ -793,6 +799,7 @@
 1,Lonnie Carroll
 6,Lonnie Langford
 1,Lonut Trestian
+1,Lora Keyte
 1,Loren Martin
 1,Louie Hamlett
 1,Lucas Arias
@@ -877,6 +884,7 @@
 1,Max Stiles
 1,Megan Cook
 1,Megan Czahar
+1,Meghan Keffer
 1,Meghan West
 1,Mel Robertson
 1,Melanie Meyer
@@ -930,6 +938,7 @@
 3,MJ Moscola
 2,MK Walker
 1,Molly Foster
+1,Molly Manatee
 1,Molly McAlpin
 1,Monica Pedraza
 1,Monty Hathaway
@@ -1090,6 +1099,7 @@
 1,Sam Muchongwe
 3,Sam Snyder
 3,Sam Stiles
+1,Sam Wiedmann
 1,Sandy Fillman
 1,Sandy Magallanes
 2,Sara Morrison
@@ -1139,6 +1149,7 @@
 4,Skye Fleming
 1,Skyler Herrmann
 1,Sofia Kessler
+1,Sophia Brooks
 3,Sophie Spickard
 1,Spencer Boyer
 1,Stacy Wilson OLD


### PR DESCRIPTION
Jason Boekeloo, Benjamin Schubert, Lora Keyte, Brian Kirk, Bryan Mills, Meghan Keffer, Sophia Brooks, Clayton Coffman, Jon Bell, Molly Manatee, Sam Wiedmann

"Kevin kelly" was not added, as it's a misspelling of a legacy player (it was "Kelley" in the past).