### PR TITLE
IPR Update fix: Los Rangel

### DIFF
--- a/IPR.csv
+++ b/IPR.csv
@@ -927,7 +927,7 @@ IPR,Name
 1,Lonut Trestian
 1,Lora Keyte
 1,Loren Martin
-6,Los Rangel
+2,Los Rangel
 1,Louie Hamlett
 1,Lucas Arias
 3,Lucas Haines


### PR DESCRIPTION
Dave said his name will change soon in IFPA and I forgot to include the manual fix. Was 6 because of invalid 3 letter name. Now 2 because that's his real IPR.